### PR TITLE
Removed the functions only deployment

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -34,9 +34,9 @@ jobs:
           path: lib
       - name: Install Dependencies
         run: npm ci
-      - name: Deploy to Firebase functions
+      - name: Deploy to Firebase
         uses: w9jds/firebase-action@master
         with:
-          args: deploy --only functions
+          args: deploy
         env:
           FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}


### PR DESCRIPTION
### Changelog
- Removed `firebase deploy --only functions` and replaced with `firebase deploy` to trigger all component deployment